### PR TITLE
Switched to Java 1.8 to be consistent with all microservices

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<name>openapi</name>
 	<description>A centralized implementation of OpenAPI for all microservices</description>
 	<properties>
-		<java.version>11</java.version>
+		<java.version>1.8</java.version>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
Packaging and running from command line does not work consistently with all microservices due to differences in java version (discovered via launch automation in reverse-proxy repo). This change matches the project to be consistent along with the other microservices and run on Java 1.8