### PR TITLE
ITB-212: unified url to swagger and changed links

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,21 +1,22 @@
 # Springdoc OpenAPI config
 springdoc.api-docs.groups.enabled=true
-springdoc.swagger-ui.path=/swagger
+springdoc.api-docs.path = /swagger/v3/api-docs
+springdoc.swagger-ui.path=/swagger/
 
 springdoc.swagger-ui.urls[0].name=Account Service
-springdoc.swagger-ui.urls[0].url=/v3/api-docs/accountservice
+springdoc.swagger-ui.urls[0].url=/user/v3/api-docs
 
 springdoc.swagger-ui.urls[1].name=Search Service
-springdoc.swagger-ui.urls[1].url=/v3/api-docs/searchservice
+springdoc.swagger-ui.urls[1].url=/search/v3/api-docs
 
 springdoc.swagger-ui.urls[2].name=Restaurant Service
-springdoc.swagger-ui.urls[2].url=/v3/api-docs/restaurantservice
+springdoc.swagger-ui.urls[2].url=/restaurant/v3/api-docs
 
 springdoc.swagger-ui.urls[3].name=Order Service
-springdoc.swagger-ui.urls[3].url=/v3/api-docs/orderservice
+springdoc.swagger-ui.urls[3].url=/order/v3/api-docs
 
 springdoc.swagger-ui.urls[4].name=Payment Service
-springdoc.swagger-ui.urls[4].url=/v3/api-docs/paymentservice
+springdoc.swagger-ui.urls[4].url=/payment/v3/api-docs
 
 springdoc.swagger-ui.urls[5].name=Delivery Service
-springdoc.swagger-ui.urls[5].url=/v3/api-docs/deliveryservice
+springdoc.swagger-ui.urls[5].url=/delivery/v3/api-docs


### PR DESCRIPTION
Changed the URL to access the UI to /swagger/
Changed the swagger-config to begin with /swagger/
Changed the URLs for other microservices to the appropriate unified URL